### PR TITLE
Correct invalid keywords.txt KEYWORD_TOKENTYPE

### DIFF
--- a/Iibrary/keywords.txt
+++ b/Iibrary/keywords.txt
@@ -14,6 +14,6 @@ serialReadInt	KEYWORD2
 getRandomNumber	KEYWORD2
 degToRads	KEYWORD2
 radsToDeg	KEYWORD2
-hsv2rgb	KEYWORD 2
+hsv2rgb	KEYWORD2
 
 # Constants (LITERAL1)


### PR DESCRIPTION
Use of an invalid `KEYWORD_TOKENTYPE` value in keywords.txt causes the keyword to be colored by the default `editor.function.style` (as used by `KEYWORD2`, `KEYWORD3`, `LITERAL2`) in Arduino IDE 1.6.5 and newer. On Arduino IDE 1.6.4 and older this will cause the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keyword_tokentype